### PR TITLE
Implemented automatic documentation generation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,8 @@ on:
       - 'release/**'
     types: [opened, reopened, edited, synchronize]
     paths:
-      - '**.js'
+      - '*.js'
+      - 'test/**'
       - 'import-font.css'
       - 'pwd-font.ttf'
 jobs:

--- a/.github/workflows/buildChrome.yml
+++ b/.github/workflows/buildChrome.yml
@@ -3,10 +3,11 @@ on:
   pull_request:
     branches:
       - 'master'
-      - 'dev'
+      - 'release/**'
     types: [opened, reopened, edited, synchronize]
     paths:
-      - '**.js'
+      - '*.js'
+      - 'test/**'
       - 'import-font.css'
       - 'pwd-font.ttf'
 jobs:

--- a/.github/workflows/buildFF.yml
+++ b/.github/workflows/buildFF.yml
@@ -3,10 +3,11 @@ on:
   pull_request:
     branches:
       - 'master'
-      - 'dev'
+      - 'release/**'
     types: [opened, reopened, edited, synchronize]
     paths:
-      - '**.js'
+      - '*.js'
+      - 'test/**'
       - 'import-font.css'
       - 'pwd-font.ttf'
 jobs:

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -1,0 +1,31 @@
+name: generate-docs
+on:
+  push:
+    branches:
+      - 'master'
+      - 'release/**'
+    paths:
+      - '*.js'
+      - '!karma.conf.js'
+      - 'package.json'
+      - 'docs/**'
+jobs:
+  generate-docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: npm i
+    - name: Import GPG key
+      uses: crazy-max/ghaction-import-gpg@v2
+      with:
+        git_user_signingkey: true
+        git_commit_gpgsign: true
+      env:
+        GPG_PRIVATE_KEY: ${{ secrets.KASKADI_BOT_GPG_PRIVATE_KEY }}
+        PASSPHRASE: ${{ secrets.KASKADI_BOT_GPG_PRIVATE_PASSPHRASE }}
+    - name: Generate documentation
+      uses: kaskadi/action-generate-docs@master
+      with:
+        type: element
+        template: docs/template.md

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,11 +5,12 @@ on:
       - 'master'
       - 'release/**'
     paths:
-      - '**.js'
-      - 'import-font.css'
-      - 'pwd-font.ttf'
+      - '*.js'
+      - '!karma.conf.js'
       - 'example/index.html'
       - 'package.json'
+      - 'import-font.css'
+      - 'pwd-font.ttf'
 env:
   AWS_KEY_ID: ${{ secrets.AWS_KEY_ID }}
   AWS_KEY_SECRET: ${{ secrets.AWS_KEY_SECRET }}
@@ -21,10 +22,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install dependencies
       run: npm i
-    - uses: paambaati/codeclimate-action@v2.4.0
-      env:
-        CC_TEST_REPORTER_ID: ${{ secrets.REPORTER_ID }}
-      with:
-        coverageCommand: npm run coverage
+    - name: Test
+      run: npm test
     - name: Upload files to S3 bucket
       uses: kaskadi/action-s3cp@master

--- a/docs/template.md
+++ b/docs/template.md
@@ -1,0 +1,33 @@
+![](https://img.shields.io/github/package-json/v/kaskadi/kaskadi-passwordbox)
+![](https://img.shields.io/badge/code--style-standard-blue)
+![](https://img.shields.io/github/license/kaskadi/kaskadi-passwordbox?color=blue)
+
+[![](https://img.shields.io/badge/live-example-orange)](https://cdn.klimapartner.net/modules/%40kaskadi/kaskadi-passwordbox/example/index.html)
+
+**GitHub Actions workflows status**
+
+[![Build status](https://img.shields.io/github/workflow/status/kaskadi/kaskadi-passwordbox/build?label=build&logo=mocha)](https://github.com/kaskadi/kaskadi-passwordbox/actions?query=workflow%3Abuild)
+[![BuildFF status](https://img.shields.io/github/workflow/status/kaskadi/kaskadi-passwordbox/build-on-firefox?label=firefox&logo=Mozilla%20Firefox&logoColor=white)](https://github.com/kaskadi/kaskadi-passwordbox/actions?query=workflow%3Abuild-on-firefox)
+[![BuildChrome status](https://img.shields.io/github/workflow/status/kaskadi/kaskadi-passwordbox/build-on-chrome?label=chrome&logo=Google%20Chrome&logoColor=white)](https://github.com/kaskadi/kaskadi-passwordbox/actions?query=workflow%3Abuild-on-chrome)
+[![Publish status](https://img.shields.io/github/workflow/status/kaskadi/kaskadi-passwordbox/publish?label=publish&logo=Amazon%20AWS)](https://github.com/kaskadi/kaskadi-passwordbox/actions?query=workflow%3Apublish)
+[![Docs generation status](https://img.shields.io/github/workflow/status/kaskadi/kaskadi-passwordbox/generate-docs?label=docs&logo=read-the-docs)](https://github.com/kaskadi/kaskadi-passwordbox/actions?query=workflow%3Agenerate-docs)
+
+**CodeClimate**
+
+[![](https://img.shields.io/codeclimate/maintainability/kaskadi/kaskadi-passwordbox?label=maintainability&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/kaskadi-passwordbox)
+[![](https://img.shields.io/codeclimate/tech-debt/kaskadi/kaskadi-passwordbox?label=technical%20debt&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/kaskadi-passwordbox)
+[![](https://img.shields.io/codeclimate/coverage/kaskadi/kaskadi-passwordbox?label=test%20coverage&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/kaskadi-passwordbox)
+
+**LGTM**
+
+[![](https://img.shields.io/lgtm/grade/javascript/github/kaskadi/kaskadi-passwordbox?label=code%20quality&logo=LGTM)](https://lgtm.com/projects/g/kaskadi/kaskadi-passwordbox/?mode=list&logo=LGTM)
+
+<!-- You can add badges inside of this section if you'd like -->
+
+****
+
+<!-- automatically generated documentation will be placed in here -->
+{{>main}}
+<!-- automatically generated documentation will be placed in here -->
+
+<!-- You can customize this template as you'd like! -->

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -10,6 +10,10 @@ module.exports = config => {
         istanbul: { esModules: true }
       }
     },
+    proxies: {
+      '/import-font.css': '/base/import-font.css',
+      '/pwd-font.ttf': '/base/pwd-font.ttf'
+    },
     reporters: ['progress', 'coverage'],
     port: 9876, // karma web server port
     colors: true,

--- a/kaskadi-passwordbox.js
+++ b/kaskadi-passwordbox.js
@@ -1,5 +1,4 @@
 /* eslint-env browser, mocha */
-// import { css, html } from 'https://cdn.klimapartner.net/modules/lit-element/lit-element.js'
 import { KaskadiElement, css, html } from 'https://cdn.klimapartner.net/modules/@kaskadi/kaskadi-element/kaskadi-element.js'
 import 'https://cdn.klimapartner.net/modules/@kaskadi/kaskadi-textbox/kaskadi-textbox.js'
 
@@ -9,7 +8,6 @@ class KaskadiPasswordbox extends KaskadiElement {
   constructor () {
     super()
     this.labelHidden = false
-    this.lang = 'en'
     this.icon = ''
   }
 
@@ -26,7 +24,6 @@ class KaskadiPasswordbox extends KaskadiElement {
 
   static get properties () {
     return {
-      lang: { type: String },
       labelHidden: { type: Boolean },
       label: { type: Array },
       icon: { type: String }

--- a/kaskadi-passwordbox.js
+++ b/kaskadi-passwordbox.js
@@ -4,6 +4,24 @@ import 'https://cdn.klimapartner.net/modules/@kaskadi/kaskadi-textbox/kaskadi-te
 
 const cssFontLoadPath = window.location.href.includes('localhost') ? window.location.pathname.includes('example') ? '../import-font.css' : './import-font.css' : 'https://cdn.klimapartner.net/modules/@kaskadi/kaskadi-passwordbox/import-font.css'
 
+/**
+ * Element to offer a textbox for inputting password.
+ *
+ * User input will be obfuscated to make password invisible to other users watching the same screen.
+ *
+ * This element inherits properties from a base class `KaskadiElement`. To see which properties are available, please refer to [`KaskadiElement` documentation](https://github.com/kaskadi/kaskadi-element).
+ *
+ * @module kaskadi-passwordbox
+ *
+ * @param {Object} label - a set of labels that will be displayed for this textbox. Each field in the object reference to a language (f.e. `en`, `de`, `fr`, etc.).
+ * @param {string} [icon] - an icon to display for this textbox. Must be a URL pointing to a public image.
+ * @param {boolean} [labelHidden=false] - control whether the textbox label & icon should be shown.
+ *
+ * @example
+ *
+ * <kaskadi-passwordbox lang="en" label='{"en": "Password", "de": "Passwort", "fr": "Mot de passe"}' icon="https://example.com/lock.png"></kaskadi-passwordbox>
+ */
+
 class KaskadiPasswordbox extends KaskadiElement {
   constructor () {
     super()
@@ -51,4 +69,5 @@ class KaskadiPasswordbox extends KaskadiElement {
     <kaskadi-textbox id="pwd-box" lang="${this.lang}" ?labelHidden="${this.labelHidden}" icon="${this.icon}" .label="${this.label}" spellcheck="false"></kaskadi-textbox>`
   }
 }
+
 customElements.define('kaskadi-passwordbox', KaskadiPasswordbox)


### PR DESCRIPTION
**Changes description**
Implemented automatic documentation generation using `action-generate-docs` as GitHub Action inside of a `generate-docs` workflow. This uses a template for documentation generation located under `docs/template.md`. Also did a bit of cleanup (fix in workflows + code)

**New features**
- _`generate-docs` workflow:_ using `action-generate-docs` GitHub Action and a template this workflow automatically generates documentation for this element
- _documentation template:_ located at `docs/template.md` this file serves as base for the documentation generation

**Updated features**
- _build workflows:_ fixed triggers
- _`publish` workflow:_ fixed `publish` workflow triggers and workflow logic|
- _tests:_ added proxy to local file to avoid 404 warnings
- _main file:_ added JSDoc comments for documentation and removed lang attribute (inherits from `KaskadiElement`)